### PR TITLE
Update 03a-joins.md

### DIFF
--- a/Instructions/Labs/03a-joins.md
+++ b/Instructions/Labs/03a-joins.md
@@ -209,7 +209,7 @@ This section contains suggested solutions for the challenge queries.
     FROM SalesLT.Customer AS c
     JOIN SalesLT.SalesOrderHeader AS oh
         ON oh.CustomerID = c.CustomerID;
-        ```
+    ```
  
 2. Retrieve customer orders with addresses:
 


### PR DESCRIPTION
Fixed the indentation of ``` to render a proper markdown of the SQL statement.

Problem: The rendering of the SQL code block was not proper.
![image](https://github.com/user-attachments/assets/5674dbdf-8f93-499d-b82c-78ec45e5306c)

# Module: 03
## Lab/Demo: a

Changes proposed in this pull request:

- Removed the extra indentation before ``` sign that marks the end of the code block.