### PR TITLE
Backfill missing lab metadata (14 files)

### DIFF
--- a/Instructions/Labs/01-get-started-with-tsql.md
+++ b/Instructions/Labs/01-get-started-with-tsql.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Get Started with Transact-SQL'
-    module: 'Module 1: Getting Started with Transact-SQL'
+  title: Get Started with Transact-SQL
+  module: 'Module 1: Getting Started with Transact-SQL'
+  description: In this exercise, you will use some basic SELECT queries to retrieve data from the AdventureWorks database.
+  duration: 124 minutes
+  level: 100
+  islab: true
 ---
 
 # Get Started with Transact-SQL

--- a/Instructions/Labs/02-filter-sort.md
+++ b/Instructions/Labs/02-filter-sort.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Sort and Filter Query Results'
-    module: 'Module 2: Sorting and Filtering Query Results'
+  title: Sort and Filter Query Results
+  module: 'Module 2: Sorting and Filtering Query Results'
+  description: In this exercise, you'll use the Transact-SQL SELECT statement to query and filter data in the AdventureWorks database.
+  duration: 148 minutes
+  level: 100
+  islab: true
 ---
 
 # Sort and Filter Query Results

--- a/Instructions/Labs/03a-joins.md
+++ b/Instructions/Labs/03a-joins.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Query Multiple Tables with Joins'
-    module: 'Module 3: Using Joins and Subqueries'
+  title: Query Multiple Tables with Joins
+  module: 'Module 3: Using Joins and Subqueries'
+  description: In this exercise, you'll use the Transact-SQL SELECT statement to query multiple tables in the Adventureworks database.
+  duration: 98 minutes
+  level: 100
+  islab: true
 ---
 
 # Query Multiple Tables with Joins

--- a/Instructions/Labs/03b-subqueries.md
+++ b/Instructions/Labs/03b-subqueries.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Use Subqueries'
-    module: 'Module 3: Using Joins and Subqueries'
+  title: Use Subqueries
+  module: 'Module 3: Using Joins and Subqueries'
+  description: In this exercise, you'll use subqueries to retrieve data from tables in the adventureworks database.
+  duration: 80 minutes
+  level: 100
+  islab: true
 ---
 
 # Use Subqueries

--- a/Instructions/Labs/04-built-in-functions.md
+++ b/Instructions/Labs/04-built-in-functions.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Use Built-in Functions'
-    module: 'Module 4: Using Built-in Functions'
+  title: Use Built-in Functions
+  module: 'Module 4: Using Built-in Functions'
+  description: In this exercise, you'll use built-in functions to retrieve and aggregate data in the Adventureworks database.
+  duration: 114 minutes
+  level: 100
+  islab: true
 ---
 
 # Use Built-in Functions

--- a/Instructions/Labs/05-modify-data.md
+++ b/Instructions/Labs/05-modify-data.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Modify Data'
-    module: 'Module 5: Modifying Data'
+  title: Modify Data
+  module: 'Module 5: Modifying Data'
+  description: In this exercise, you'll insert, update, and delete data in the Adventureworks database.
+  duration: 134 minutes
+  level: 100
+  islab: true
 ---
 
 # Modify Data

--- a/Instructions/Labs/06-use-table-expressions.md
+++ b/Instructions/Labs/06-use-table-expressions.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Create queries with table expressions'
-    module: 'Additional exercises'
+  title: Create queries with table expressions
+  module: Additional exercises
+  description: In this exercise, you'll use table expressions to query the Adventureworks database.
+  duration: 66 minutes
+  level: 100
+  islab: true
 ---
 
 # Create queries with table expressions

--- a/Instructions/Labs/07-combine-query-results.md
+++ b/Instructions/Labs/07-combine-query-results.md
@@ -1,8 +1,13 @@
 ---
 lab:
-    title: 'Combine query results with set operators'
-    module: 'Additional exercises'
+  title: Combine query results with set operators
+  module: Additional exercises
+  description: In this lab, you will use set operators to retrieve results from the Adventureworks database.
+  duration: 56 minutes
+  level: 100
+  islab: true
 ---
+
 # Combine query results with set operators
 
 In this lab, you will use set operators to retrieve results from the **Adventureworks** database.

--- a/Instructions/Labs/08-create-window-query-functions.md
+++ b/Instructions/Labs/08-create-window-query-functions.md
@@ -1,8 +1,13 @@
 ---
 lab:
-    title: 'Use window functions'
-    module: 'Additional exercises'
+  title: Use window functions
+  module: Additional exercises
+  description: In this exercise, you'll apply window functions on the Adventureworks database.
+  duration: 36 minutes
+  level: 100
+  islab: true
 ---
+
 # Use window functions
 
 In this exercise, you'll apply window functions on the **Adventureworks** database.

--- a/Instructions/Labs/09-transform-data.md
+++ b/Instructions/Labs/09-transform-data.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Use pivoting and grouping sets'
-    module: 'Additional exercises'
+  title: Use pivoting and grouping sets
+  module: Additional exercises
+  description: In this exercise, you'll use pivoting and grouping sets to query the Adventureworks database.
+  duration: 50 minutes
+  level: 100
+  islab: true
 ---
 
 # Use pivoting and grouping sets

--- a/Instructions/Labs/10-program-with-tsql.md
+++ b/Instructions/Labs/10-program-with-tsql.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Introduction to programming with Transact-SQL'
-    module: 'Additional exercises'
+  title: Introduction to programming with Transact-SQL
+  module: Additional exercises
+  description: In this exercise, you'll use get an introduction to programming with Transact-SQL using the Adventureworks database.
+  duration: 80 minutes
+  level: 100
+  islab: true
 ---
 
 # Introduction to programming with Transact-SQL

--- a/Instructions/Labs/11-create-stored-procedures.md
+++ b/Instructions/Labs/11-create-stored-procedures.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Create stored procedures and functions in Transact-SQL'
-    module: 'Additional exercises'
+  title: Create stored procedures and functions in Transact-SQL
+  module: Additional exercises
+  description: In this exercise, you'll create and run stored procedures in the Adventureworks database.
+  duration: 72 minutes
+  level: 100
+  islab: true
 ---
 
 # Create stored procedures and functions in Transact-SQL

--- a/Instructions/Labs/12-implement-error-handling.md
+++ b/Instructions/Labs/12-implement-error-handling.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Implement error handling with Transact-SQL'
-    module: 'Additional exercises'
+  title: Implement error handling with Transact-SQL
+  module: Additional exercises
+  description: In this exercise, you'll use various Transact-SQL error handling techniques.
+  duration: 68 minutes
+  level: 100
+  islab: true
 ---
 
 # Implement error handling with Transact-SQL

--- a/Instructions/Labs/13-implement-transitions-in-tsql.md
+++ b/Instructions/Labs/13-implement-transitions-in-tsql.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Implement transactions with Transact SQL'
-    module: 'Additional exercises'
+  title: Implement transactions with Transact SQL
+  module: Additional exercises
+  description: In this exercise you'll use a transaction to ensure that when a row is inserted into the Customer and Address tables, a row is also added to the CustomerAddress table to create a link between the customer record and the address record. If one insert fails, then all should fail.
+  duration: 72 minutes
+  level: 100
+  islab: true
 ---
 
 # Implement transactions with Transact SQL


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 14

- `Instructions/Labs/01-get-started-with-tsql.md` (description,duration,level,islab)
- `Instructions/Labs/02-filter-sort.md` (description,duration,level,islab)
- `Instructions/Labs/03a-joins.md` (description,duration,level,islab)
- `Instructions/Labs/03b-subqueries.md` (description,duration,level,islab)
- `Instructions/Labs/04-built-in-functions.md` (description,duration,level,islab)
- `Instructions/Labs/05-modify-data.md` (description,duration,level,islab)
- `Instructions/Labs/06-use-table-expressions.md` (description,duration,level,islab)
- `Instructions/Labs/07-combine-query-results.md` (description,duration,level,islab)
- `Instructions/Labs/08-create-window-query-functions.md` (description,duration,level,islab)
- `Instructions/Labs/09-transform-data.md` (description,duration,level,islab)
- `Instructions/Labs/10-program-with-tsql.md` (description,duration,level,islab)
- `Instructions/Labs/11-create-stored-procedures.md` (description,duration,level,islab)
- `Instructions/Labs/12-implement-error-handling.md` (description,duration,level,islab)
- `Instructions/Labs/13-implement-transitions-in-tsql.md` (description,duration,level,islab)
